### PR TITLE
Restrict agents package requirements to <1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-livekit-agents>=0.12.11
-livekit-plugins-openai>=0.10.17
-livekit-plugins-cartesia>=0.4.7
-livekit-plugins-deepgram>=0.6.17
-livekit-plugins-silero>=0.7.4
-livekit-plugins-turn-detector>=0.4.0
+livekit-agents>=0.12.11,<1.0.0
+livekit-plugins-openai>=0.10.17,<1.0.0
+livekit-plugins-cartesia>=0.4.7,<1.0.0
+livekit-plugins-deepgram>=0.6.17,<1.0.0
+livekit-plugins-silero>=0.7.4,<1.0.0
+livekit-plugins-turn-detector>=0.4.0,<1.0.0
 python-dotenv~=1.0


### PR DESCRIPTION
Updating the package requirements to ensure that we only pull versions prior to v1.0.0 in order to maintain compatibility with the implementation in this example.